### PR TITLE
Improved scrolling in tab view with a search filter active

### DIFF
--- a/Source/DSGUI/TabModal/DSGUI_TabModal.cs
+++ b/Source/DSGUI/TabModal/DSGUI_TabModal.cs
@@ -56,17 +56,19 @@ namespace DSGUI {
             maxWeight = deepStorageComp.limitingTotalFactorForCell * slotCount;
         }
 
-        protected override void FillTab() {
+        protected override void FillTab()
+        {
             var buildingStorage = SelThing as Building_Storage;
             storedItems = SetStoredItems(buildingStorage);
             if (storedItems == null)
                 return;
 
-            if (buildingStorage != lastStorage || !storedItems.Equals(lastItems)) {
+            if (buildingStorage != lastStorage || !storedItems.Equals(lastItems))
+            {
                 SetStorageProperties(buildingStorage?.GetComp<CompDeepStorage>());
-                rows        = new List<DSGUI_TabItem>();
+                rows = new List<DSGUI_TabItem>();
                 lastStorage = buildingStorage;
-                lastItems   = new List<Thing>(storedItems);
+                lastItems = new List<Thing>(storedItems);
             }
 
             if (storedItems.Count >= 1 && rows.OptimizedNullOrEmpty())
@@ -74,64 +76,57 @@ namespace DSGUI {
                     rows.Add(new DSGUI_TabItem(thing, Drop));
 
             var mainRect = new Rect(4f, 2f, size.x - 8f, size.y - 6f);
-            GUI.color   = Color.white;
-            Text.Font   = GameFont.Small;
+            GUI.color = Color.white;
+            Text.Font = GameFont.Small;
             Text.Anchor = TextAnchor.MiddleLeft;
 
             // Make Header
-            var headRect  = new Rect(mainRect) {height = 36f};
+            var headRect = new Rect(mainRect) {height = 36f};
             var headTitle = headRect.LeftPartPixels(62f);
-            var headInfo  = headRect.RightPartPixels(headRect.width - 69f);
-            headInfo.y     += 1f;
+            var headInfo = headRect.RightPartPixels(headRect.width - 69f);
+            headInfo.y += 1f;
             headInfo.width -= 26f;
             Widgets.Label(headTitle, labelKey);
             DSGUI.Elements.SeparatorVertical(headTitle.width + 2f, headRect.y, headRect.height);
-            Text.Font   = GameFont.Tiny;
+            Text.Font = GameFont.Tiny;
             Text.Anchor = TextAnchor.MiddleLeft;
             Widgets.Label(headInfo, $"{curCount} / {maxCount} Stacks (min. {minCount})\n{curWeight:0.##} / {maxWeight:0.##} kg");
             DSGUI.Elements.SeparatorHorizontal(headRect.x, headRect.height + 5f, headRect.width);
             var headSub = new Rect(mainRect) {height = 18f};
             headSub.y += headRect.height + 8f;
+            
+            var filteredRows = searchString.NullOrEmpty()
+                ? rows
+                : rows.Where(x => x.Label.IndexOf(searchString, StringComparison.OrdinalIgnoreCase) >= 0).ToList();
 
-            // Scrollable List
-            var scrollRect = new Rect(mainRect);
-            scrollRect.y      += headRect.height + 10f;
-            scrollRect.height -= headRect.height + 48f;
-            scrollHeight      =  storedItems.Count * boxHeight;
-            var viewRect = new Rect(0.0f, 0.0f, scrollRect.width - 16f, scrollHeight);
-            Widgets.BeginScrollView(scrollRect, ref scrollPosition, viewRect);
-            GUI.BeginGroup(viewRect);
             if (DSGUIMod.Settings.DSGUI_Tab_SortContent && rows.Count > 1)
                 if (DSGUIMod.Settings.DSGUI_Tab_AdvSortContent)
-                    rows = rows.OrderBy(x => x.Label).ThenByDescending(x => {
+                    filteredRows = filteredRows.OrderBy(x => x.Label).ThenByDescending(x =>
+                    {
                         x.Target.TryGetQuality(out var c);
                         return (int) c;
                     }).ThenByDescending(x => x.Target.HitPoints / x.Target.MaxHitPoints).ToList();
                 else
-                    rows = rows.OrderBy(x => x.Label).ToList();
+                    filteredRows = filteredRows.OrderBy(x => x.Label).ToList();
+            
+            // Scrollable List
+            var scrollRect = new Rect(mainRect);
+            scrollRect.y += headRect.height + 10f;
+            scrollRect.height -= headRect.height + 48f;
+            scrollHeight = boxHeight * filteredRows.Count;
+            var viewRect = new Rect(0.0f, 0.0f, scrollRect.width - 16f, scrollHeight);
 
-            if (rows.Count == 0) {
+            Widgets.BeginScrollView(scrollRect, ref scrollPosition, viewRect);
+            GUI.BeginGroup(viewRect);
+
+            if (rows.Count == 0)
+            {
                 Widgets.Label(viewRect, "NoItemsAreStoredHere".TranslateSimple());
             }
-            else {
-                var i = 0;
-                if (searchString.NullOrEmpty()) {
-                    foreach (var tabItem in rows) {
-                        tabItem.DoDraw(viewRect, i);
-                        i++;
-                    }
-
-                    scrollHeight = boxHeight * rows.Count;
-                }
-                else {
-                    var filteredRows = rows.Where(x => x.Label.IndexOf(searchString, StringComparison.OrdinalIgnoreCase) >= 0).ToList();
-                    foreach (var tabItem in filteredRows) {
-                        tabItem.DoDraw(viewRect, i);
-                        i++;
-                    }
-
-                    scrollHeight = boxHeight * filteredRows.Count;
-                }
+            else
+            {
+                for (var index = 0; index < filteredRows.Count; index++)
+                    filteredRows[index].DoDraw(viewRect, index);
             }
 
             GUI.EndGroup();
@@ -139,11 +134,11 @@ namespace DSGUI {
 
             // Search
             var search = new Rect(scrollRect);
-            search.x     += 3f;
+            search.x += 3f;
             search.width -= 3f;
-            search.y     += scrollRect.height + 10f;
+            search.y += scrollRect.height + 10f;
             DSGUI.Elements.SearchBar(search, 6f, ref searchString);
-            GUI.color   = Color.white;
+            GUI.color = Color.white;
             Text.Anchor = TextAnchor.UpperLeft;
         }
     }


### PR DESCRIPTION
With this improvement, the scrollbar size changes to reflect the number of filtered results:

![image](https://user-images.githubusercontent.com/5466350/135342901-98d41764-aacb-4e23-8167-f57ca6cee0b9.png)
to
![image](https://user-images.githubusercontent.com/5466350/135342861-a85c7db2-c739-4b74-9a4f-9ac999b8b076.png)
